### PR TITLE
Added version in transport parameters for resumption

### DIFF
--- a/src/crypto/transport.parameters.ts
+++ b/src/crypto/transport.parameters.ts
@@ -2,6 +2,9 @@ import { Constants } from '../utilities/constants';
 import { EndpointType } from '../types/endpoint.type';
 import { QuicError } from '../utilities/errors/connection.error';
 import { ConnectionErrorCodes } from '../utilities/errors/quic.codes';
+import { Version } from '../packet/header/header.properties';
+import { HandshakeState } from './qtls';
+import { Bignum } from '../types/bignum';
 
 
 // hardcoded, in this order, at https://tools.ietf.org/html/draft-ietf-quic-transport#section-6.4.1
@@ -19,7 +22,7 @@ export enum TransportParameterType {
     MAX_PACKET_SIZE = 0x05,             // maximum total packet size (at UDP level)
     STATELESS_RESET_TOKEN = 0x06,       // token to be used in the case of a stateless reset 
     ACK_DELAY_EXPONENT = 0x07,          // congestion control tweaking parameter, see congestion/ack handling logic 
-    INITIAL_MAX_STREAMS_UNI = 0x08      // maximum amount of uni-directional streams that can be opened// UPDATE-12 TODO: rename to initial_max_uni_streams
+    INITIAL_MAX_STREAMS_UNI = 0x08     // maximum amount of uni-directional streams that can be opened// UPDATE-12 TODO: rename to initial_max_uni_streams
 }
 
 /**
@@ -39,12 +42,15 @@ export class TransportParameters {
     private statelessResetToken!: Buffer;
     private ackDelayExponent!: number;
 
+    private version!: Version;
+
     // these three parameters MUST be set for each connection, so we require them in the constructor 
-    public constructor(isServer: boolean, maxStreamData: number, maxData: number, idleTimeout: number) {
+    public constructor(isServer: boolean, maxStreamData: number, maxData: number, idleTimeout: number, version: Version) {
         this.isServer = isServer;
         this.maxStreamData = maxStreamData;
         this.maxData = maxData;
         this.idleTimeout = idleTimeout;
+        this.version = version;
     }
 
     // REFACTOR TODO: most of these values have a minimum and maximum allowed value: check for these here! 
@@ -100,7 +106,11 @@ export class TransportParameters {
         return undefined;
     }
 
-    public toBuffer(): Buffer {
+    public getVersion(): Version {
+        return this.version;
+    }
+
+    private getTransportParametersBuffer(): Buffer {
         var buffer = Buffer.alloc(this.getBufferSize());
         var offset = 0;
         var bufferOffset: BufferOffset = {
@@ -126,6 +136,50 @@ export class TransportParameters {
             bufferOffset = this.writeTransportParameter(TransportParameterType.ACK_DELAY_EXPONENT, bufferOffset, this.ackDelayExponent);
         }
         return bufferOffset.buffer;
+    }
+
+    /**
+     * Builts a buffer from the transport parameters AND the negotiated version
+     *  --> Is the same buffer as the extensionDataBuffer, except that the first four bytes also contain the version
+     *  this buffer is used to perform session resumption by the client
+     *  function is thus used for application side
+     */
+    public toBuffer(): Buffer {
+        var transportParameterersBuffer = this.getTransportParametersBuffer();
+        var buf = Buffer.alloc(transportParameterersBuffer.byteLength + 4);
+        buf.write(this.version.toString(), 0, 4, 'hex');
+        transportParameterersBuffer.copy(buf, 4);
+        return buf;
+    }
+
+    /**
+     * Builts a buffer from the transport parameters and the necessary version parts which are mandatory 
+     *      (initial version for the client| negotiated version + supported version for the server)
+     *  this buffer is used to pass to C++ side to send it to the other endpoint
+     *  function is thus used for internal use only.
+     */
+    public toExtensionDataBuffer(handshakeState: HandshakeState, version: Version): Buffer {
+        var transportParamBuffer = this.getTransportParametersBuffer();
+        var transportExt = Buffer.alloc(this.getExtensionDataSize(transportParamBuffer, handshakeState));
+        var offset = 0;
+        if (this.isServer) {
+            // version in the connection holds the negotiated version
+            transportExt.write(version.toString(), offset, 4, 'hex');
+            offset += 4;
+            transportExt.writeUInt8(Constants.SUPPORTED_VERSIONS.length * 4, offset++);
+            Constants.SUPPORTED_VERSIONS.forEach((version: string) => {
+                transportExt.write(version, offset, 4, 'hex');
+                offset += 4;
+            });
+        } else {
+            console.log("version in the client initial: " + version.toString());
+            transportExt.write(version.toString(), offset, 4, 'hex');
+            offset += 4;
+        }
+        transportExt.writeUInt16BE(transportParamBuffer.byteLength, offset);
+        offset += 2;
+        transportParamBuffer.copy(transportExt, offset);
+        return transportExt;
     }
 
     private writeTypeAndLength(type: TransportParameterType, buffer: Buffer, offset: number, length: number): BufferOffset {
@@ -183,10 +237,14 @@ export class TransportParameters {
         return size;
     }
 
-    public static fromBuffer(isServer: boolean, buffer: Buffer): TransportParameters {
+    /**
+     * Rebuild transport parameters from a buffer object which is obtained from the other endpoint and received from C++ side.
+     *  function is for internal use.
+     */
+    public static fromExtensionBuffer(isServer: boolean, buffer: Buffer, version: Version): TransportParameters {
         var values: { [index: number]: any; } = [];
         var offset = 0;
-        var transportParameters = new TransportParameters(isServer, -1, -1, -1);
+        var transportParameters = new TransportParameters(isServer, -1, -1, -1, version);
         while (offset < buffer.byteLength) {
             var type = buffer.readUInt16BE(offset);
             offset += 2;
@@ -209,9 +267,21 @@ export class TransportParameters {
             // Ignore unknown transport parameters
             if (key in TransportParameterType) {
                 transportParameters.setTransportParameter(Number(key), values[key]);
+            } else {
             }
         }
         return transportParameters;
+    }
+
+    /**
+     * Rebuild transport parameters from a buffer object (passed to the client).
+     *  The first 4 bytes contain the negotiated version and the rest is the same as the extensionBuffer
+     *  This function must be used for application 
+     */
+    public static fromBuffer(isServer: boolean, buffer: Buffer): TransportParameters {
+        var version = new Version(Buffer.from(buffer.readUInt32BE(0).toString(16), 'hex'));
+        var tpBuffer = buffer.slice(4);
+        return TransportParameters.fromExtensionBuffer(isServer, tpBuffer, version);
     }
 
     private getTransportParameterTypeByteSize(type: TransportParameterType): number {
@@ -236,6 +306,39 @@ export class TransportParameters {
                 return 2;
         }
         return 0;
+    }
+
+    /**
+     * Method to get transport parameters with default values, which are set in the constants file
+     * @param isServer 
+     * @param version 
+     */
+    public static getDefaultTransportParameters(isServer: boolean, version: Version): TransportParameters {
+        var transportParameters = new TransportParameters(isServer, Constants.DEFAULT_MAX_STREAM_DATA, Constants.DEFAULT_MAX_DATA, Constants.DEFAULT_IDLE_TIMEOUT, version);
+            transportParameters.setTransportParameter(TransportParameterType.ACK_DELAY_EXPONENT, Constants.DEFAULT_ACK_EXPONENT);
+            if (isServer) {
+                transportParameters.setTransportParameter(TransportParameterType.INITIAL_MAX_STREAMS_BIDI, Constants.DEFAULT_MAX_STREAM_CLIENT_BIDI);
+                transportParameters.setTransportParameter(TransportParameterType.INITIAL_MAX_STREAMS_UNI, Constants.DEFAULT_MAX_STREAM_CLIENT_UNI);
+                // TODO: better to calculate this value
+                transportParameters.setTransportParameter(TransportParameterType.STATELESS_RESET_TOKEN, Bignum.random('ffffffffffffffffffffffffffffffff', 16).toBuffer());
+            } else {
+                transportParameters.setTransportParameter(TransportParameterType.INITIAL_MAX_STREAMS_BIDI, Constants.DEFAULT_MAX_STREAM_SERVER_BIDI);
+                transportParameters.setTransportParameter(TransportParameterType.INITIAL_MAX_STREAMS_UNI, Constants.DEFAULT_MAX_STREAM_SERVER_UNI);
+            }
+        return transportParameters;
+    }
+
+    /**
+     * Calculate the size of the buffer which is passed to C++ for openssl
+     */
+    private getExtensionDataSize(transportParamBuffer: Buffer, handshakeState: HandshakeState): number {
+        if (this.isServer) {
+            if (handshakeState === HandshakeState.HANDSHAKE) {
+                return transportParamBuffer.byteLength + 6 + Constants.SUPPORTED_VERSIONS.length * 4 + 1;
+            }
+            return transportParamBuffer.byteLength + 2;
+        }
+        return transportParamBuffer.byteLength + 6;
     }
 }
 

--- a/src/crypto/transport.parameters.ts
+++ b/src/crypto/transport.parameters.ts
@@ -172,7 +172,6 @@ export class TransportParameters {
                 offset += 4;
             });
         } else {
-            console.log("version in the client initial: " + version.toString());
             transportExt.write(version.toString(), offset, 4, 'hex');
             offset += 4;
         }

--- a/src/quicker/client.ts
+++ b/src/quicker/client.ts
@@ -15,6 +15,8 @@ import { QuickerErrorCodes } from '../utilities/errors/quicker.codes';
 import { isIPv6 } from 'net';
 import { Socket, createSocket, RemoteInfo } from 'dgram';
 import { Endpoint } from './endpoint';
+import { ConnectionErrorCodes } from '../utilities/errors/quic.codes';
+import { QuicError } from '../utilities/errors/connection.error';
 
 export class Client extends Endpoint {
 
@@ -144,6 +146,10 @@ export class Client extends Endpoint {
             this.connection.startIdleAlarm();
         } catch (err) {
             if (err instanceof QuickerError && err.getErrorCode() === QuickerErrorCodes.IGNORE_PACKET_ERROR) {
+                return;
+            }
+            if (err instanceof QuicError && err.getErrorCode() === ConnectionErrorCodes.VERSION_NEGOTIATION_ERROR) {
+                this.emit(QuickerEvent.ERROR, err);
                 return;
             }
             this.handleError(this.connection, err);

--- a/src/quicker/client.ts
+++ b/src/quicker/client.ts
@@ -117,10 +117,6 @@ export class Client extends Endpoint {
         this.connection.getQuicTLS().setSession(buffer);
     }
 
-    public setTransportParameters(tp: Buffer): void {
-        return this.connection.setRemoteTransportParameters(TransportParameters.fromBuffer(false, tp));
-    }
-
     public isSessionReused(): boolean {
         return this.connection.getQuicTLS().isSessionReused();
     }

--- a/src/quicker/connection.ts
+++ b/src/quicker/connection.ts
@@ -424,11 +424,14 @@ export class Connection extends FlowControlledObject {
         this.spinBit = spinbit;
     }
 
-    public resetConnection() {
+    public resetConnection(negotiatedVersion?: Version) {
         this.resetConnectionState();
         this.getStreamManager().getStreams().forEach((stream: Stream) => {
             stream.reset();
         });
+        if (negotiatedVersion !== undefined) {
+            this.setVersion(negotiatedVersion);
+        }
         this.startConnection();
     }
 

--- a/src/utilities/handlers/packet.handler.ts
+++ b/src/utilities/handlers/packet.handler.ts
@@ -70,8 +70,11 @@ export class PacketHandler {
     }
 
     private handleVersionNegotiationPacket(connection: Connection, versionNegotiationPacket: VersionNegotiationPacket): void {
-        // REFACTOR TODO: we should only react to the first VersionNegotationPacket, see https://tools.ietf.org/html/draft-ietf-quic-transport#section-6.2.2
-        // not sure if this is checked anywhere yet, but I doubt it 
+        // we should only react to the first VersionNegotationPacket, see https://tools.ietf.org/html/draft-ietf-quic-transport#section-6.2.2
+        if (connection.getVersion().toString() !== connection.getInitialVersion().toString()) {
+            return;
+        }
+
         var versionNegotiationHeader = <VersionNegotiationHeader>versionNegotiationPacket.getHeader();
         var connectionId = versionNegotiationHeader.getSrcConnectionID();
         var connectionId = versionNegotiationHeader.getDestConnectionID();
@@ -80,28 +83,33 @@ export class PacketHandler {
             // https://tools.ietf.org/html/draft-ietf-quic-transport#section-6.2.2
             throw new QuicError(ConnectionErrorCodes.VERSION_NEGOTIATION_ERROR, "Version negotation didn't include correct connectionID values");
         }
-        var negotiatedVersion = undefined;
 
-        // REFACTOR TODO: we MUST ignore this packet if it contains our chosen version, see https://tools.ietf.org/html/draft-ietf-quic-transport-12#section-6.2.2
+        // we MUST ignore this packet if it contains our chosen version, see https://tools.ietf.org/html/draft-ietf-quic-transport-12#section-6.2.2
+        var containsChosenVersion = false;
+        versionNegotiationPacket.getVersions().forEach((version: Version) => {
+            containsChosenVersion = containsChosenVersion || (version.toString() === connection.getInitialVersion().toString());
+        });
+        if (containsChosenVersion) {
+            return;
+        }
 
-        // REFACTOR TODO: make sure we select the highest possible version? versions in negpacket aren't necessarily ordered? 
+        // make sure we select the highest possible version? versions in negpacket aren't necessarily ordered? 
+        var negotiatedVersion: Version | undefined = undefined;
         versionNegotiationPacket.getVersions().forEach((version: Version) => {
             var index = Constants.SUPPORTED_VERSIONS.indexOf(version.toString());
             if (index > -1) {
-                negotiatedVersion = version;
-                return;
+                if (negotiatedVersion === undefined) {
+                    negotiatedVersion = version;
+                } else {
+                    negotiatedVersion = version.toString() > negotiatedVersion.toString() ? version : negotiatedVersion;
+                }
             }
         });
         if (negotiatedVersion === undefined) {
             // REFACTOR TODO: this isn't caught anywhere at client side yet (only on server)... needs to be caught and propagated to library user! 
             throw new QuicError(ConnectionErrorCodes.VERSION_NEGOTIATION_ERROR, "No supported version overlap found between Client and Server");
         }
-        // REFACTOR TODO: why does this work? shouldn't we set the version before resetting the connection OR calling startConnection() ourselves instead of in resetConnection?
-        // how does this even work? resetConnection() re-inits the handshake, so new version shouldn't be selected?
-        // unless, of course, this is because we call into C++/work with a callback, in which case this is still dirty
-        // REFACTOR TODO: pass new version into the resetConnection() method directly? 
-        connection.resetConnection();
-        connection.setVersion(negotiatedVersion);
+        connection.resetConnection(negotiatedVersion);
     }
 
     // only on SERVER (client sends ClientInitial packet)

--- a/src/utilities/validation/handshake.validation.ts
+++ b/src/utilities/validation/handshake.validation.ts
@@ -2,6 +2,7 @@ import { Connection } from '../../quicker/connection';
 import { EndpointType } from '../../types/endpoint.type';
 import { HandshakeState } from '../../crypto/qtls';
 import { TransportParameters } from '../../crypto/transport.parameters';
+import { Version } from '../../packet/header/header.properties';
 
 export class HandshakeValidation {
 
@@ -28,7 +29,7 @@ export class HandshakeValidation {
         offset += 2;
         var transportParamBuffer = Buffer.alloc(length);
         extensionData.copy(transportParamBuffer, 0, offset);
-        var transportParameters: TransportParameters = TransportParameters.fromBuffer(isServer, transportParamBuffer);
+        var transportParameters: TransportParameters = TransportParameters.fromExtensionBuffer(isServer, transportParamBuffer, new Version(Buffer.from(version.toString(16), 'hex')));
         
         return transportParameters;
     }


### PR DESCRIPTION
Solves issue #5 
Previously, version was not kept in transport parameters
This resulted that the "active version" of the client was always used, even for session resumption even though the initial connection did a version negotiation.
This fix adds the version to the transport parameters buffer to set the previous version in the new connection, if it is still supported by the client

Also moved the logic of creating the extension data, which is passed to C++ side, to the transport parameters file instead of the qtls file.